### PR TITLE
Small fix for email link in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,4 +55,4 @@ If you are working on something in one of these categories, we will not accept y
 
 In case of problems with trying to contribute to Iron Fish, you can contact us:
 * On [Discord](https://discord.gg/ironfish)
-* Via [email](contact@ironfish.network)
+* Via [email](mailto:contact@ironfish.network)


### PR DESCRIPTION
We have missed "mailto:" property. As a result, by clicking on the email we are redirected as by clicking on regular link while should be opened a mail client. Adding "mailto:" property is solving this problem.

## Summary

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[ ] No
```
